### PR TITLE
Skipping global matches in a RegExp

### DIFF
--- a/src/helpers/QueryParser.js
+++ b/src/helpers/QueryParser.js
@@ -128,7 +128,7 @@ export default class QueryParser {
     }
     // To remove first | character
     pattern = pattern.slice(1);
-    return new RegExp(pattern, 'g');
+    return new RegExp(pattern);
   }
 
   static getFirstCombinator(element, combinators) {


### PR DESCRIPTION
Remove the -g modifier from the RexExp in the getSearchPattern() in order to avoid global matches for the operator values.